### PR TITLE
Mobile specific and other styling fixes

### DIFF
--- a/src/components/AllMap.js
+++ b/src/components/AllMap.js
@@ -148,6 +148,7 @@ function FMAMap({
                 }) {
     const [center, setCenter] = useState(DEFAULT_CENTER);
     const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+    const [showLegend, setShowLegend] = useState(false);
 
     useEffect(() => { fetchIncidents?.(); }, [fetchIncidents]);
 
@@ -202,20 +203,24 @@ function FMAMap({
                 </MapContainer>
 
                 {/* Legenda (por estado) */}
-                <div style={{
-                    position: 'absolute', top: 8, right: 8, background: 'rgba(255,255,255,0.92)', zIndex: 1000,
-                    borderRadius: 8, padding: '6px 10px', boxShadow: '0 1px 3px rgba(0,0,0,.12)', fontSize: 12
-                }}>
-                    {Object.entries(STATUS_COLORS).map(([label, color]) => (
-                        <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-              <span style={{
-                  width: 10, height: 10, borderRadius: '50%', background: color, display: 'inline-block',
-                  border: '2px solid rgba(0,0,0,0.1)'
-              }} />
-                            <span>{label}</span>
-                        </div>
-                    ))}
-                </div>
+                {showLegend ? (
+                    <div onClick={() => setShowLegend(false)}
+                         className="cursor-pointer absolute bottom-6 right-1 z-[1000] bg-white bg-opacity-90
+                                    px-2 py-1.5 rounded-lg text-xs leading-[1.5] shadow-sm"
+                         style={{
+                    }}>
+                        {Object.entries(STATUS_COLORS).map(([label, color]) => (
+                            <div key={label} style={{display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4}}>
+                                <span className="w-[10px] h-[10px] rounded-full inline-block border-2 border-black/10"
+                                      style={{background: color,}}/>
+                                <span>{label}</span>
+                            </div>
+                        ))}
+                    </div>
+                ) : <button className="cursor-pointer absolute bottom-6 right-2 bg-white text-gray-700 bg-opacity-80 px-3 py-2 rounded-full text-2xl z-[1000]"
+                            onClick={() => setShowLegend(true)}>
+                    🛈
+                </button>}
 
                 {incidents?.loading && <div className="map-banner">A carregar…</div>}
                 {incidents?.error && <div className="map-banner map-banner--error">{incidents.error}</div>}

--- a/src/components/FMA.js
+++ b/src/components/FMA.js
@@ -152,60 +152,60 @@ class FMA extends Component {
 
         return (
             <div className="shadow-lg mx-auto bg-white mt-24 md:mt-16 w-screen overflow-x-hidden">
-                <div className="container my-12 mx-auto px-4 md:px-12">
+                <div className="container md:my-12 mx-auto px-4 md:px-12">
                     <div className="flex flex-wrap -mx-1 lg:-mx-4">
                         <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                            <div className="overflow-hidden rounded-lg shadow-lg">
-                                <header className="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-                                    <p className="text-gray-800 text-6xl text-center">{totals.totalIncidents} 🚨</p>
-                                </header>
-                                <footer className="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                    <p className="text-center text-sm">Total Ocorrências</p>
-                                </footer>
+                            <div
+                                className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                                <div className="text-6xl">🚨</div>
+                                <div>
+                                    <p className="text-6xl text-grey-darker md:text-center">{totals.totalIncidents}</p>
+                                    <p>Total Ocorrências</p>
+                                </div>
                             </div>
                         </div>
 
                         <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                            <div className="overflow-hidden rounded-lg shadow-lg">
-                                <header className="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-                                    <p className="text-gray-800 text-6xl text-center">{totals.totalMan} 👨‍🚒</p>
-                                </header>
-                                <footer className="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                    <p className="text-center text-sm">Total Operacionais</p>
-                                </footer>
+                            <div
+                                className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                                <div className="text-6xl">👨‍🚒</div>
+                                <div>
+                                    <p className="text-6xl text-grey-darker md:text-center">{totals.totalMan}</p>
+                                    <p>Total Operacionais</p>
+                                </div>
                             </div>
                         </div>
 
                         <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                            <div className="overflow-hidden rounded-lg shadow-lg">
-                                <header className="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-                                    <p className="text-gray-800 text-6xl text-center">{totals.totalTerrain} 🚒</p>
-                                </header>
-                                <footer className="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                    <p className="text-center text-sm">Total Veículos</p>
-                                </footer>
+                            <div
+                                className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                                <div className="text-6xl">🚒</div>
+                                <div>
+                                    <p className="text-6xl text-grey-darker md:text-center">{totals.totalTerrain}</p>
+                                    <p>Total Veículos</p>
+                                </div>
                             </div>
                         </div>
 
                         <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                            <div className="overflow-hidden rounded-lg shadow-lg">
-                                <header className="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-                                    <p className="text-gray-800 text-6xl text-center">{totals.totalAerial} 🚁</p>
-                                </header>
-                                <footer className="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                    <p className="text-center text-sm">Total Aéreos</p>
-                                </footer>
+                            <div
+                                className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                                <div className="text-6xl">🚁</div>
+                                <div>
+                                    <p className="text-6xl text-grey-darker md:text-center">{totals.totalAerial}</p>
+                                    <p>Total Aéreos</p>
+                                </div>
                             </div>
                         </div>
 
                         <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                            <div className="overflow-hidden rounded-lg shadow-lg">
-                                <header className="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-                                    <p className="text-gray-800 text-6xl text-center">{totals.totalBoat} 🚣</p>
-                                </header>
-                                <footer className="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                    <p className="text-center text-sm">Total Aquáticos</p>
-                                </footer>
+                            <div
+                                className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                                <div className="text-6xl">🚣</div>
+                                <div>
+                                    <p className="text-6xl text-grey-darker md:text-center">{totals.totalBoat}</p>
+                                    <p>Total Aquáticos</p>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/src/components/FMA.js
+++ b/src/components/FMA.js
@@ -151,7 +151,7 @@ class FMA extends Component {
             );
 
         return (
-            <div className="shadow-lg mx-auto bg-white mt-24 md:mt-16 h-screen">
+            <div className="shadow-lg mx-auto bg-white mt-24 md:mt-16 w-screen overflow-x-hidden">
                 <div className="container my-12 mx-auto px-4 md:px-12">
                     <div className="flex flex-wrap -mx-1 lg:-mx-4">
                         <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
@@ -252,7 +252,7 @@ class FMA extends Component {
                 </div>
 
                 <div className="-mx-4 sm:-mx-8 px-4 sm:px-8 py-4 overflow-x-auto">
-                    <div className="inline-block min-w-full shadow rounded-lg overflow-hidden">
+                    <div className="inline-block min-w-full shadow rounded-lg overflow-x-scroll max-w-full">
                         <table className="min-w-full leading-normal">
                             <thead>
                             <tr>

--- a/src/components/FMAMap.js
+++ b/src/components/FMAMap.js
@@ -148,6 +148,7 @@ function FMAMap({
                 }) {
     const [center, setCenter] = useState(DEFAULT_CENTER);
     const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+    const [showLegend, setShowLegend] = useState(false);
 
     useEffect(() => { fetchFMAIncidents?.(); }, [fetchFMAIncidents]);
 
@@ -202,20 +203,24 @@ function FMAMap({
                 </MapContainer>
 
                 {/* Legenda (por estado) */}
-                <div style={{
-                    position: 'absolute', top: 8, right: 8, background: 'rgba(255,255,255,0.92)', zIndex: 1000,
-                    borderRadius: 8, padding: '6px 10px', boxShadow: '0 1px 3px rgba(0,0,0,.12)', fontSize: 12
-                }}>
-                    {Object.entries(STATUS_COLORS).map(([label, color]) => (
-                        <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-              <span style={{
-                  width: 10, height: 10, borderRadius: '50%', background: color, display: 'inline-block',
-                  border: '2px solid rgba(0,0,0,0.1)'
-              }} />
-                            <span>{label}</span>
-                        </div>
-                    ))}
-                </div>
+                {showLegend ? (
+                    <div onClick={() => setShowLegend(false)}
+                         className="cursor-pointer absolute bottom-6 right-1 z-[1000] bg-white bg-opacity-90
+                                    px-2 py-1.5 rounded-lg text-xs leading-[1.5] shadow-sm"
+                         style={{
+                         }}>
+                        {Object.entries(STATUS_COLORS).map(([label, color]) => (
+                            <div key={label} style={{display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4}}>
+                                <span className="w-[10px] h-[10px] rounded-full inline-block border-2 border-black/10"
+                                      style={{background: color,}}/>
+                                <span>{label}</span>
+                            </div>
+                        ))}
+                    </div>
+                ) : <button className="cursor-pointer absolute bottom-6 right-2 bg-white text-gray-700 bg-opacity-80 px-3 py-2 rounded-full text-2xl z-[1000]"
+                            onClick={() => setShowLegend(true)}>
+                    🛈
+                </button>}
 
                 {incidents?.loading && <div className="map-banner">A carregar…</div>}
                 {incidents?.error && <div className="map-banner map-banner--error">{incidents.error}</div>}

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -205,7 +205,7 @@ class List extends Component {
 
 
     return (
-        <div className="shadow-lg mx-auto bg-white mt-24 md:mt-16 h-screen">
+        <div className="shadow-lg mx-auto bg-white mt-24 md:mt-16 w-screen overflow-x-hidden">
             <div className="container my-12 mx-auto px-4 md:px-12">
                 <div className="flex flex-wrap -mx-1 lg:-mx-4">
                     <div class="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
@@ -316,7 +316,7 @@ class List extends Component {
                 </div>
             </div>
           <div className="-mx-4 sm:-mx-8 px-4 sm:px-8 py-4 overflow-x-auto">
-				<div className="inline-block min-w-full shadow rounded-lg overflow-hidden">
+				<div className="inline-block min-w-full shadow rounded-lg overflow-x-scroll max-w-full">
 					<table className="min-w-full leading-normal">
 						<thead>
 							<tr>

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -206,85 +206,60 @@ class List extends Component {
 
     return (
         <div className="shadow-lg mx-auto bg-white mt-24 md:mt-16 w-screen overflow-x-hidden">
-            <div className="container my-12 mx-auto px-4 md:px-12">
+            <div className="container md:my-12 mx-auto px-4 md:px-8">
                 <div className="flex flex-wrap -mx-1 lg:-mx-4">
-                    <div class="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                        <div class="overflow-hidden rounded-lg shadow-lg">
-                            <header class="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-
-                                <p class="text-grey-darker text-6xl text-center">
-                                    {this.state.totalIncidents} 🚨
-                                </p>
-                            </header>
-
-                            <footer class="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                               <p className="text-center text-sm">Total Ocorrências</p>
-                            </footer>
-
+                    <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
+                        <div
+                            className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                            <div className="text-6xl">🚨</div>
+                            <div>
+                                <p className="text-6xl text-grey-darker md:text-center">{this.state.totalIncidents}</p>
+                                <p>Total Ocorrências</p>
+                            </div>
                         </div>
                     </div>
 
-                    <div class="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                        <div class="overflow-hidden rounded-lg shadow-lg">
-                            <header class="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-
-                                <p class="text-grey-darker text-6xl text-center">
-                                    {this.state.totalMan} 👨‍🚒
-                                </p>
-                            </header>
-
-                            <footer class="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                <p className="text-center text-sm">Total Operacionais</p>
-                            </footer>
-
+                    <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
+                        <div
+                            className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                            <div className="text-6xl">👨‍🚒</div>
+                            <div>
+                                <p className="text-6xl text-grey-darker md:text-center">{this.state.totalMan}</p>
+                                <p>Total Operacionais</p>
+                            </div>
                         </div>
                     </div>
 
-                    <div class="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                        <div class="overflow-hidden rounded-lg shadow-lg">
-                            <header class="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-
-                                <p class="text-grey-darker text-6xl text-center">
-                                    {this.state.totalTerrain} 🚒
-                                </p>
-                            </header>
-
-                            <footer class="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                <p className="text-center text-sm">Total Veículos</p>
-                            </footer>
-
+                    <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
+                        <div
+                            className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                            <div className="text-6xl">🚒</div>
+                            <div>
+                                <p className="text-6xl text-grey-darker md:text-center">{this.state.totalTerrain}</p>
+                                <p>Total Veículos</p>
+                            </div>
                         </div>
                     </div>
 
-                    <div class="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                        <div class="overflow-hidden rounded-lg shadow-lg">
-                            <header class="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-
-                                <p class="text-grey-darker text-6xl text-center">
-                                    {this.state.totalAerial} 🚁
-                                </p>
-                            </header>
-
-                            <footer class="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                <p className="text-center text-sm">Total Aéreos</p>
-                            </footer>
-
+                    <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
+                        <div
+                            className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                            <div className="text-6xl">🚁</div>
+                            <div>
+                                <p className="text-6xl text-grey-darker md:text-center">{this.state.totalAerial}</p>
+                                <p>Total Aéreos</p>
+                            </div>
                         </div>
                     </div>
 
-                    <div class="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
-                        <div class="overflow-hidden rounded-lg shadow-lg">
-                            <header class="flex items-center justify-between leading-tight p-2 md:p-4 place-content-center">
-
-                                <p class="text-grey-darker text-6xl text-center">
-                                    {this.state.totalBoat} 🚣
-                                </p>
-                            </header>
-
-                            <footer class="flex items-center justify-between leading-none p-2 md:p-4 place-content-center">
-                                <p className="text-center text-sm">Total Aquáticos</p>
-                            </footer>
-
+                    <div className="my-1 px-1 w-full md:w-1/2 lg:my-4 lg:px-4 lg:w-1/5">
+                        <div
+                            className="overflow-hidden rounded-lg shadow-lg flex md:flex-col items-center md:justify-center p-4 gap-4">
+                            <div className="text-6xl">🚣</div>
+                            <div>
+                                <p className="text-6xl text-grey-darker md:text-center">{this.state.totalBoat}</p>
+                                <p>Total Aquáticos</p>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -8,7 +8,7 @@ class NavBar extends Component {
 
     render() {
         return (
-            <nav className="fixed inset-x-0 top-0 bg-blue-500 h-16 z-[1000]">
+            <nav className="fixed inset-x-0 top-0 bg-blue-500 h-16 z-[1000] w-screen">
                 <div className="max-w-6xl mx-auto px-4 h-16">
                     <div className="flex justify-between h-16">
                         <div className="flex space-x-4">
@@ -26,8 +26,8 @@ class NavBar extends Component {
                         </div>
 
                         <div className="md:hidden flex items-center">
-                            <button className="mobile-menu-button focus:outline-none" onClick={this.addActiveClass}>
-                                <i className="bx bx-menu text-3xl mt-1 text-white" />
+                            <button className="mobile-menu-button text-white text-2xl" onClick={this.addActiveClass}>
+                                ☰
                             </button>
                         </div>
                     </div>
@@ -41,9 +41,10 @@ class NavBar extends Component {
                             : 'hidden'
                     }
                 >
-                    <Link to="/" className="block py-2 px-4 text-sm hover:bg-gray-200" onClick={this.addActiveClass}>Início</Link>
                     <Link to="/lista" className="block py-2 px-4 text-sm hover:bg-gray-200" onClick={this.addActiveClass}>Lista</Link>
+                    <Link to="/mapa" className="block py-2 px-4 text-sm hover:bg-gray-200" onClick={this.addActiveClass}>Mapa</Link>
                     <Link to="/fma" className="block py-2 px-4 text-sm hover:bg-gray-200" onClick={this.addActiveClass}>FMA</Link>
+                    <Link to="/fma-mapa" className="block py-2 px-4 text-sm hover:bg-gray-200" onClick={this.addActiveClass}>Mapa FMA</Link>
                 </div>
             </nav>
         );


### PR DESCRIPTION
This PR fixes some issues with the website when viewed on mobile:

- The navigation items were supposed to show up when a hamburger icon was pressed, but it was not visible
  - Navbar width has been locked to screen width and the icon is now visible
  - Missing navigation items added to the dropdown menu
- The page extended horizontally due to the table overflowing on the x-axis
  - Page width has been locked to screen width, if the table overflows, it can be scrolled without scrolling the entire page
- Changed "total" information cards styling to it looks aligned a bit better

Before / After:
<p float="left">
<img width="200" src="https://github.com/user-attachments/assets/c85b9a8d-e15f-408e-b941-165ad7cf112e" />
<img width="200" src="https://github.com/user-attachments/assets/2e23b598-8033-451d-aad7-614bb2a0359d" />
</p>

<p float="left">
<img width="200" src="https://github.com/user-attachments/assets/944d19dd-cfef-468b-91b7-7a81413458c5" />
<img width="200" src="https://github.com/user-attachments/assets/13923836-93b7-42d7-aa4b-ab2010dd34bb" />
</p>

<p float="left">
<img width="400" src="https://github.com/user-attachments/assets/879b7aa2-fc73-4437-a798-4254703f5ef9" />
<img width="400" src="https://github.com/user-attachments/assets/e94dce69-d0d4-4b30-9e72-c8f3a9cc2767" />
</p>

- The map legend was in the way of the zoom in/out buttons, so it was moved to the bottom, and can be toggled through a button

Before / After (Hidden) / After (Visible):
<p float="left">
<img width="200" src="https://github.com/user-attachments/assets/81f93e99-d6c8-47a6-8b81-f4db917f081b" />
<img width="200" src="https://github.com/user-attachments/assets/fc2ced80-47e2-41df-b12c-38865b21a4ba" />
<img width="200"  src="https://github.com/user-attachments/assets/f73f24c5-5089-41ab-b677-b695e6ec7e55" />
</p>

Hope this is helpful